### PR TITLE
Adds upgrade event hook

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -56,6 +56,7 @@ class PostgresqlDataK8SCharm(charm.CharmBase):
 
         # General hooks:
         self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.upgrade_charm, self._on_upgrade)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.update_status, self._on_update_status)
 
@@ -98,6 +99,20 @@ class PostgresqlDataK8SCharm(charm.CharmBase):
         This will install the postgresql-client dependency, which contains the pg_restore binary
         used by this charm.
         """
+        self._install_client()
+
+    def _on_upgrade(self, _):
+        """Handles the charm upgrade hook.
+
+        This will install the postgresql-client dependency, which contains the pg_restore binary
+        used by this charm.
+
+        If a Pod is respawned, the install and start hooks are not triggered, but this one is.
+        We need this in order to ensure that the dependency exists.
+        """
+        self._install_client()
+
+    def _install_client(self):
         proc = subprocess.Popen(["apt", "update"], stdout=subprocess.PIPE)
         proc.wait()
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -98,6 +98,25 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.model.unit.status, model.ActiveStatus())
 
     @mock.patch("subprocess.Popen")
+    def test_on_upgrade(self, mock_popen):
+        self.harness.begin_with_initial_hooks()
+
+        cmd_update = ["apt", "update"]
+        cmd_install = ["apt", "install", "-y", "postgresql-client"]
+        mock_calls = [
+            mock.call(cmd_update, stdout=subprocess.PIPE),
+            mock.call(cmd_install, stdout=subprocess.PIPE),
+        ]
+
+        # Assert initial calls from on_install hook.
+        mock_popen.assert_has_calls(mock_calls, any_order=True)
+        mock_popen.reset_mock()
+
+        # Trigger upgrade and make assertions.
+        self.harness.charm.on.upgrade_charm.emit()
+        mock_popen.assert_has_calls(mock_calls, any_order=True)
+
+    @mock.patch("subprocess.Popen")
     def test_config_changed(self, mock_popen):
         """Test for the config updated hook."""
         # We don't have a PostgreSQL charm, so the charm should be in Blocked Status.


### PR DESCRIPTION
If a Pod is rebuilt in Kubernetes for any reason, it won't trigger the on install hook anymore, meaning that the new Pod will not have the postgresql-client installed, which can cause the charm to misbehave.

An upgrade hook is triggered when the Pod is rebuilt, so we're adding a hook for that, in which we'll install the postgresql-client. Note that the upgrade event is no triggered when first deploying the charm, which is why we're keeping that event hook.