### PR TITLE
Removes noop container from metadata.yaml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ If there are any other issues, ``charmcraft clean`` might help.
 After the charm has been built, you will be able to find it in the local folder. You can then deploy it with the command:
 
 ```bash
-juju deploy ./postgresql-data-k8s_ubuntu-20.04-amd64.charm --resource noop-image=google/pause
+juju deploy ./postgresql-data-k8s_ubuntu-20.04-amd64.charm
 ```
 
 If it was already deployed, you can simply refresh it:

--- a/README.md
+++ b/README.md
@@ -47,10 +47,6 @@ juju config postgresql-data-k8s refresh-period=60
 
 This charm requires an ``db-admin`` relation, typically provided by the ``postgresql-k8s`` charm.
 
-## OCI Images
-
-This Charm does not use a Workload Container, how an OCI image is still required to deploy the charm. Any noop image can be used; but it is recommended to use a pause image (``google/pause``).
-
 ## Charm releases
 
 This repository is configured to automatically build and publish a new Charm revision after a Pull Request merges. For more information, see [here](docs/CharmPublishing.md).

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -23,12 +23,3 @@ requires:
     interface: pgsql
     limit: 1
     scope: global
-
-containers:
-  noop:
-    resource: noop-image
-
-resources:
-  noop-image:
-    type: oci-image
-    description: OCI image for the no-nop container (google/pause).


### PR DESCRIPTION
We no longer need a workload container for the charm. This will simplify deploying and publishing.