### PR TITLE
actions: Update runner to 22.04

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish-charm:
     name: Publish Charm to edge
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 20.04 runners have been disabled recently, and actions using them are stuck in a pending state. Update them to 22.04.